### PR TITLE
net: lib: aws_iot: Added support for run-time endpoint host name config

### DIFF
--- a/doc/nrf/libraries/networking/aws_iot.rst
+++ b/doc/nrf/libraries/networking/aws_iot.rst
@@ -90,6 +90,8 @@ Complete the following steps to set the required library options:
 
 1. In the `AWS IoT console`_, navigate to :guilabel:`IoT core` > :guilabel:`Settings`.
 #. Find the ``Device data endpoint`` address and set :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME` to this address string.
+   The address can also be provided at runtime by setting the :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP` option.
+   See :ref:`lib_set_aws_hostname` for more details.
 #. Set the option :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` to the name of the *Thing* created earlier in the process.
    This is not needed if the application sets the client ID at run time.
    If you still want to set a custom client ID, make sure that the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP` is disabled and set the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC` option to your desired client ID.
@@ -118,6 +120,8 @@ Other options:
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP`
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_STATIC`
 * :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN`
+* :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN`
+* :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP`
 
 
 .. note::
@@ -155,6 +159,15 @@ Setting client ID at run-time
 
 The AWS IoT library also supports passing in the client ID at run time.
 To enable this feature, set the ``client_id`` entry in the :c:struct:`aws_iot_config` structure that is passed in the :c:func:`aws_iot_init` function when initializing the library, and set the :kconfig:option:`CONFIG_AWS_IOT_CLIENT_ID_APP` Kconfig option.
+
+.. _lib_set_aws_hostname:
+
+Setting the AWS host name at runtime
+====================================
+
+The AWS IoT library also supports passing the endpoint address at runtime by setting the :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_APP` option.
+If this option is set, the ``host_name`` and ``host_name_len`` must be set in the :c:struct:`aws_iot_config` structure before it is passed into the :c:func:`aws_iot_init` function.
+The length of your AWS host name (:kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME`) must be shorter than the default value of :kconfig:option:`CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN`, for proper initialization of the library.
 
 AWS FOTA
 ========

--- a/include/net/aws_iot.h
+++ b/include/net/aws_iot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -187,6 +187,13 @@ struct aws_iot_config {
 	char *client_id;
 	/** Length of client_id string. */
 	size_t client_id_len;
+	/** AWS IoT endpoint host name for broker connection, used when
+	 *  @kconfig{CONFIG_AWS_IOT_BROKER_HOST_NAME_APP} is set. If not the
+	 *  static @kconfig{AWS_IOT_BROKER_HOST_NAME} is used.
+	 */
+	char *host_name;
+	/** Length of host_name string. */
+	size_t host_name_len;
 };
 
 /** @brief Initialize the module.

--- a/subsys/net/lib/aws_iot/Kconfig
+++ b/subsys/net/lib/aws_iot/Kconfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Nordic Semiconductor
+# Copyright (c) 2022 Nordic Semiconductor
 #
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
@@ -45,8 +45,12 @@ config AWS_IOT_STATIC_IPV4_ADDR
 config AWS_IOT_SEC_TAG
 	int "Security tag to use for AWS IoT connection"
 
+config AWS_IOT_BROKER_HOST_NAME_APP
+	bool "AWS IoT sever hostname provided by application run-time"
+
 config AWS_IOT_BROKER_HOST_NAME
 	string "AWS IoT server hostname"
+	depends on !AWS_IOT_BROKER_HOST_NAME_APP
 
 config AWS_IOT_PORT
 	int "AWS server port"
@@ -69,6 +73,10 @@ config AWS_IOT_IPV6
 config AWS_IOT_APP_SUBSCRIPTION_LIST_COUNT
 	int "Amount of entries in the application subscription list"
 	default 0
+
+config AWS_IOT_BROKER_HOST_NAME_MAX_LEN
+	int "Maximum length of broker host name"
+	default 64
 
 config AWS_IOT_CLIENT_ID_MAX_LEN
 	int "Maximum length of cliend id"

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Nordic Semiconductor ASA
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
@@ -21,14 +21,23 @@
 
 LOG_MODULE_REGISTER(aws_iot, CONFIG_AWS_IOT_LOG_LEVEL);
 
+/* Check if the static host name is set and if its buffer is larger enough if
+ * static host name is used
+ */
+#if !defined(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP)
 BUILD_ASSERT(sizeof(CONFIG_AWS_IOT_BROKER_HOST_NAME) > 1,
 	    "AWS IoT hostname not set");
+BUILD_ASSERT(CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN >=
+	     sizeof(CONFIG_AWS_IOT_BROKER_HOST_NAME) - 1,
+	     "AWS IoT host name static buffer too small "
+	     "Increase CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN");
+#endif /* !defined(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP) */
 
 /* Check that the client ID buffer is large enough if a static ID is used. */
 #if !defined(CONFIG_AWS_IOT_CLIENT_ID_APP)
 BUILD_ASSERT(CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN >=
 	     sizeof(CONFIG_AWS_IOT_CLIENT_ID_STATIC) - 1,
-	     "AWS IoT client ID static buffer to small "
+	     "AWS IoT client ID static buffer too small "
 	     "Increase CONFIG_AWS_IOT_CLIENT_ID_MAX_LEN");
 #endif /* !defined(CONFIG_AWS_IOT_CLIENT_ID_APP */
 
@@ -102,6 +111,8 @@ static char delete_rejected_topic[DELETE_REJECTED_TOPIC_LEN + 1];
 
 /* Empty string used to request the AWS IoT shadow document. */
 #define AWS_IOT_SHADOW_REQUEST_STRING ""
+
+static char aws_host_name_buf[CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN + 1];
 
 static struct aws_iot_app_topic_data app_topic_data;
 static struct mqtt_client client;
@@ -215,6 +226,22 @@ static void aws_fota_cb_handler(struct aws_fota_event *fota_evt)
 	aws_iot_notify_event(&aws_iot_evt);
 }
 #endif
+
+static int aws_iot_set_host_name(char *const host_name, size_t host_name_len)
+{
+	if (host_name == NULL) {
+		return -EINVAL;
+	}
+
+	if (host_name_len >= sizeof(aws_host_name_buf)) {
+		return -ENOMEM;
+	}
+
+	memcpy(aws_host_name_buf, host_name, host_name_len);
+	aws_host_name_buf[host_name_len] = '\0';
+
+	return 0;
+}
 
 static int aws_iot_topics_populate(char *const id, size_t id_len)
 {
@@ -739,8 +766,7 @@ static int broker_init(void)
 		.ai_socktype = SOCK_STREAM
 	};
 
-	err = getaddrinfo(CONFIG_AWS_IOT_BROKER_HOST_NAME,
-			  NULL, &hints, &result);
+	err = getaddrinfo(aws_host_name_buf, NULL, &hints, &result);
 	if (err) {
 		LOG_ERR("getaddrinfo, error %d", err);
 		return -ECHILD;
@@ -847,7 +873,7 @@ static int client_broker_init(struct mqtt_client *const client)
 	tls_cfg->cipher_list		= NULL;
 	tls_cfg->sec_tag_count		= ARRAY_SIZE(sec_tag_list);
 	tls_cfg->sec_tag_list		= sec_tag_list;
-	tls_cfg->hostname		= CONFIG_AWS_IOT_BROKER_HOST_NAME;
+	tls_cfg->hostname		= aws_host_name_buf;
 	tls_cfg->session_cache = TLS_SESSION_CACHE_DISABLED;
 
 #if defined(CONFIG_AWS_IOT_PROVISION_CERTIFICATES)
@@ -1061,8 +1087,9 @@ int aws_iot_init(const struct aws_iot_config *const config,
 {
 	int err;
 
-	if (IS_ENABLED(CONFIG_AWS_IOT_CLIENT_ID_APP) &&
-		config == NULL) {
+	if ((IS_ENABLED(CONFIG_AWS_IOT_CLIENT_ID_APP) ||
+	     IS_ENABLED(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP)) &&
+	     (config == NULL)) {
 		LOG_ERR("config is NULL");
 		return -EINVAL;
 	}
@@ -1079,6 +1106,18 @@ int aws_iot_init(const struct aws_iot_config *const config,
 		return -ENODATA;
 	}
 
+	if (IS_ENABLED(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP) &&
+	    (config->host_name_len >= CONFIG_AWS_IOT_BROKER_HOST_NAME_MAX_LEN)) {
+		LOG_ERR("AWS host name string too long");
+		return -EMSGSIZE;
+	}
+
+	if (IS_ENABLED(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP) &&
+	    (config->host_name == NULL)) {
+		LOG_ERR("AWS host name not set in the application");
+		return -ENODATA;
+	}
+
 	if (IS_ENABLED(CONFIG_AWS_IOT_CLIENT_ID_APP)) {
 		err = aws_iot_topics_populate(config->client_id, config->client_id_len);
 	} else {
@@ -1087,6 +1126,17 @@ int aws_iot_init(const struct aws_iot_config *const config,
 
 	if (err) {
 		LOG_ERR("aws_topics_populate, error: %d", err);
+		return err;
+	}
+
+#if defined(CONFIG_AWS_IOT_BROKER_HOST_NAME_APP)
+	err = aws_iot_set_host_name(config->host_name, config->host_name_len);
+#else
+	err = aws_iot_set_host_name(CONFIG_AWS_IOT_BROKER_HOST_NAME,
+				    strlen(CONFIG_AWS_IOT_BROKER_HOST_NAME));
+#endif /* CONFIG_AWS_IOT_BROKER_HOST_NAME_APP */
+	if (err) {
+		LOG_ERR("aws_iot_set_host_name, error: %d", err);
 		return err;
 	}
 


### PR DESCRIPTION
The current state of the AWS IoT library lacks support for configuring the AWS endpoint during runtime. It is only possible to provide the URL using Kconfig. This commit adds support to provide the URL from the application during run-time by enabling a new Kconfig option. This makes the library usable in more use cases. I tested it locally on my own custom nRF52840 based gateway board. I was succesfully able to connect and publish messages to AWS using both the old method and the new method.